### PR TITLE
UIMA-6324: | and & REs may miss matches

### DIFF
--- a/ruta-core/src/main/java/org/apache/uima/ruta/rule/ComposedRuleElement.java
+++ b/ruta-core/src/main/java/org/apache/uima/ruta/rule/ComposedRuleElement.java
@@ -254,12 +254,12 @@ public class ComposedRuleElement extends AbstractRuleElement implements RuleElem
             continue;
           }
           ComposedRuleElementMatch startElementMatch = (ComposedRuleElementMatch) eachStartRuleMatch
-                  .getLastMatch(this, true);
-          List<RuleMatch> continueMatch = each.continueMatch(true, annotation, eachStartRuleMatch,
+                  .getLastMatch(this, after);
+          List<RuleMatch> continueMatch = each.continueMatch(after, annotation, eachStartRuleMatch,
                   null, startElementMatch, null, this, stream, crowd);
           for (RuleMatch startRuleMatch : continueMatch) {
             ComposedRuleElementMatch elementMatch = (ComposedRuleElementMatch) startRuleMatch
-                    .getLastMatch(this, true);
+                    .getLastMatch(this, after);
             ruleMatches.put(startRuleMatch, elementMatch);
           }
         }
@@ -327,8 +327,7 @@ public class ComposedRuleElement extends AbstractRuleElement implements RuleElem
           Map<RuleMatch, ComposedRuleElementMatch> ruleMatches, boolean direction,
           RutaStream stream) {
     // TODO hotfix: this needs a correct implementation
-    Map<RuleMatch, ComposedRuleElementMatch> result = new TreeMap<>(
-            ruleMatchComparator);
+    Map<RuleMatch, ComposedRuleElementMatch> result = new TreeMap<>(ruleMatchComparator);
     Set<Entry<RuleMatch, ComposedRuleElementMatch>> entrySet = ruleMatches.entrySet();
     Entry<RuleMatch, ComposedRuleElementMatch> largestEntry = null;
     AnnotationFS largestAnnotation = null;
@@ -336,7 +335,7 @@ public class ComposedRuleElement extends AbstractRuleElement implements RuleElem
       RuleMatch ruleMatch = entry.getKey();
       ComposedRuleElementMatch elementMatch = entry.getValue();
       if (elementMatch.matched()) {
-        result.put(ruleMatch, elementMatch);
+        result.putIfAbsent(ruleMatch, elementMatch);
       } else {
         MatchContext context = new MatchContext(getFirstElement(), ruleMatch, direction);
         AnnotationFS lastMatchedAnnotation = ruleMatch.getLastMatchedAnnotation(context, stream);
@@ -565,8 +564,7 @@ public class ComposedRuleElement extends AbstractRuleElement implements RuleElem
     RutaEnvironment environment = context.getParent().getEnvironment();
     environment.addMatchToVariable(ruleMatch, this, context, stream);
 
-    List<EvaluatedCondition> evaluatedConditions = new ArrayList<>(
-            conditions.size());
+    List<EvaluatedCondition> evaluatedConditions = new ArrayList<>(conditions.size());
     for (AbstractRutaCondition condition : conditions) {
       crowd.beginVisit(condition, null);
       EvaluatedCondition eval = condition.eval(context, stream, crowd);

--- a/ruta-core/src/test/java/org/apache/uima/ruta/rule/ComposedRuleElementTest.java
+++ b/ruta-core/src/test/java/org/apache/uima/ruta/rule/ComposedRuleElementTest.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.uima.ruta.rule;
+
+import org.apache.uima.cas.CAS;
+import org.apache.uima.ruta.engine.Ruta;
+import org.apache.uima.ruta.engine.RutaTestUtils;
+import org.junit.Test;
+
+public class ComposedRuleElementTest {
+
+  @Test
+  public void testDisjunctiveSequenceCombination() throws Exception {
+    // UIMA-6324
+    String text = "A B A B";
+
+    String script = "\"A\" {-> T1};\n";
+    script += "\"B\" {-> T2};\n";
+    script += "((T2 T1) | ( \"B\" \"A\")){-> T3} W;\n";
+    script += "((T2 T1) | ( \"B\" \"A\")){-> T4} @W;\n";
+
+    CAS cas = RutaTestUtils.getCAS(text);
+    Ruta.apply(cas, script);
+
+    RutaTestUtils.assertAnnotationsEquals(cas, 3, 1, "B A");
+    RutaTestUtils.assertAnnotationsEquals(cas, 4, 1, "B A");
+  }
+
+  @Test
+  public void testConjunctiveSequenceCombination() throws Exception {
+    // UIMA-6324
+    String text = "A B A B";
+
+    String script = "\"A\" {-> T1};\n";
+    script += "\"B\" {-> T2};\n";
+    script += "((T2 T1) & ( \"B\" \"A\")){-> T3} W;\n";
+    script += "((T2 T1) & ( \"B\" \"A\")){-> T4} @W;\n";
+
+    CAS cas = RutaTestUtils.getCAS(text);
+    Ruta.apply(cas, script);
+
+    RutaTestUtils.assertAnnotationsEquals(cas, 3, 1, "B A");
+    RutaTestUtils.assertAnnotationsEquals(cas, 4, 1, "B A");
+  }
+
+}

--- a/ruta-core/src/test/java/org/apache/uima/ruta/rule/ComposedRuleElementTest.java
+++ b/ruta-core/src/test/java/org/apache/uima/ruta/rule/ComposedRuleElementTest.java
@@ -27,6 +27,22 @@ import org.junit.Test;
 public class ComposedRuleElementTest {
 
   @Test
+  public void testDisjunctiveOnDuplicates() throws Exception {
+    // UIMA-6324
+    String text = "A B A B";
+    String script = "\"A\" {-> T1, T1};\n";
+    script += "\"A\" {-> T2};\n";
+    script += "T1{-> T3};\n";
+    script += "(T1 | T2){-> T4};\n";
+
+    CAS cas = RutaTestUtils.getCAS(text);
+    Ruta.apply(cas, script);
+
+    RutaTestUtils.assertAnnotationsEquals(cas, 3, 4, "A", "A", "A", "A");
+    RutaTestUtils.assertAnnotationsEquals(cas, 4, 2, "A", "A");
+  }
+
+  @Test
   public void testDisjunctiveSequenceCombination() throws Exception {
     // UIMA-6324
     String text = "A B A B";


### PR DESCRIPTION
- avoid overriding match linking: do not assign wrong element match to previous rulematch
- set direction in conjunction match