### PR TITLE
[UIMA-6344] Ruta: ConjunctRules fires without justification

### DIFF
--- a/ruta-core/src/main/java/org/apache/uima/ruta/rule/ComposedRuleElement.java
+++ b/ruta-core/src/main/java/org/apache/uima/ruta/rule/ComposedRuleElement.java
@@ -420,6 +420,10 @@ public class ComposedRuleElement extends AbstractRuleElement implements RuleElem
     RuleElementContainer container = getContainer();
     doMatch(after, annotation, ruleMatch, containerMatch, isStartAnchor(), stream, crowd);
     if (equals(entryPoint) && ruleApply == null) {
+      if (failed) {
+        // inform caller about the failed state using the matched info
+        ruleMatch.setMatched(false);
+      }
       result.add(ruleMatch);
     } else if (container == null) {
       result = fallback(after, failed, annotation, ruleMatch, ruleApply, containerMatch,

--- a/ruta-core/src/test/java/org/apache/uima/ruta/rule/ConjunctRulesTest.java
+++ b/ruta-core/src/test/java/org/apache/uima/ruta/rule/ConjunctRulesTest.java
@@ -116,4 +116,33 @@ public class ConjunctRulesTest {
     RutaTestUtils.assertAnnotationsEquals(cas, 2, 8, "A", "A", "B", "B", "B", "B", "A", "A");
   }
 
+  @Test
+  public void testFirstElementMatches() throws Exception {
+
+    String document = "a Bb a Bb";
+    CAS cas = RutaTestUtils.getCAS(document);
+
+    Ruta.apply(cas, "SW{-> T1} % CW{-> T3} CW{-> T4};");
+
+    RutaTestUtils.assertAnnotationsEquals(cas, 1, 0);
+    RutaTestUtils.assertAnnotationsEquals(cas, 2, 0);
+    RutaTestUtils.assertAnnotationsEquals(cas, 3, 0);
+    RutaTestUtils.assertAnnotationsEquals(cas, 4, 0);
+
+    Ruta.apply(cas, "CW{-> T1} CW{-> T2} % SW{-> T3};");
+
+    RutaTestUtils.assertAnnotationsEquals(cas, 1, 0);
+    RutaTestUtils.assertAnnotationsEquals(cas, 2, 0);
+    RutaTestUtils.assertAnnotationsEquals(cas, 3, 0);
+    RutaTestUtils.assertAnnotationsEquals(cas, 4, 0);
+
+    Ruta.apply(cas, "SW{-> T1} SW{-> T2} % CW{-> T3} CW{-> T4};");
+
+    RutaTestUtils.assertAnnotationsEquals(cas, 1, 0);
+    RutaTestUtils.assertAnnotationsEquals(cas, 2, 0);
+    RutaTestUtils.assertAnnotationsEquals(cas, 3, 0);
+    RutaTestUtils.assertAnnotationsEquals(cas, 4, 0);
+
+  }
+
 }


### PR DESCRIPTION
- fix matched info for failed lookahead