### PR TITLE
[UIMA-6309] Ruta: fallback in failed wildcard lookahead

### DIFF
--- a/ruta-core/src/test/java/org/apache/uima/ruta/rule/WildCard2Test.java
+++ b/ruta-core/src/test/java/org/apache/uima/ruta/rule/WildCard2Test.java
@@ -271,4 +271,15 @@ public class WildCard2Test {
     RutaTestUtils.assertAnnotationsEquals(cas, 2, 0);
   }
 
+  @Test
+  public void testLabelForFailedLookahead() throws Exception {
+    String document = "A x B x C x D";
+    String script = "(w1:CW{REGEXP(\"A\")} # w2:CW{REGEXP(\"C\")})->{w1{->T1};};";
+
+    CAS cas = RutaTestUtils.getCAS(document, null, null, false);
+    Ruta.apply(cas, script);
+
+    RutaTestUtils.assertAnnotationsEquals(cas, 1, 1, "A");
+  }
+
 }


### PR DESCRIPTION
- was already fixed, added test