### PR TITLE
[UIMA-6433] Update issue and PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,27 @@
+---
+name: Bug report
+about: Create a report to help us improve
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Please complete the following information:**
+ - Version: [e.g. 3.2.0]
+ - OS: [e.g. Windows, Linux, OS X]
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Apache UIMA Forum/Mailing list
+    url: https://lists.apache.org/list.html?user@uima.apache.org
+    about: Community support.
+  - name: Apache UIMA Gitter/Matrix Channel
+    url: https://gitter.im/apache/uima
+    about: Public chat channel.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,16 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.github/ISSUE_TEMPLATE/refactoring.md
+++ b/.github/ISSUE_TEMPLATE/refactoring.md
@@ -1,0 +1,10 @@
+---
+name: Refactoring (for developers)
+about: Refactor the application
+---
+
+**Describe the refactoring action**
+A clear and concise description of what the action is.
+
+**Expected benefit**
+A clear and concise description of what you expect to improve by the refactoring.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,19 @@
+**JIRA Ticket:** https://issues.apache.org/jira/browse/UIMA-XXXX
+
+**What's in the PR**
+* ...
+
+**How to test manually**
+* ...
+
+**Automatic testing**
+* [ ] PR adds/updates unit tests
+
+**Documentation**
+* [ ] PR adds/updates documentation
+
+**Organizational**
+- [ ] PR includes new dependencies. <br>
+      <sub><sup>Only dependencies under [approved licenses](http://www.apache.org/legal/resolved.html#category-a)
+      are allowed. LICENSE and NOTICE files in the respective modules where dependencies have been
+      added as well as in the project root have been updated.</sup></sub>

--- a/pom.xml
+++ b/pom.xml
@@ -152,6 +152,8 @@
                 <!-- default configuration -->
               <configuration>
                 <excludes combine.children="append">
+                  <!-- These configuration files cannot bear a license header -->
+                  <exclude>.github/**/*</exclude>
                   <!--  workaround https://issues.apache.org/jira/browse/RAT-97 -->
                   <exclude>example-projects/**</exclude>
                   <exclude>ruta-basic-type/**</exclude>


### PR DESCRIPTION
- Added PR template
- Added tentative issue templates in case we switch from Jira to GitHub Issues
- Added contact links to the "new issue" page in case we switch from Jira to GitHub Issues
- Exclude templates from RAT check