### PR TITLE
[UIMA-6458] Spurious "parsedVersion.osgiVersion" in file names in target

### DIFF
--- a/example-projects/ruta-ep-example-extensions/pom.xml
+++ b/example-projects/ruta-ep-example-extensions/pom.xml
@@ -82,8 +82,6 @@
   </dependencies>
 
   <build>
-    <!-- don't use artifactId as first part of finalName, follow instead the eclipse convention -->
-    <finalName>org.apache.uima.ruta.example.extensions_${parsedVersion.osgiVersion}</finalName>
     <pluginManagement>
       <plugins>
         <plugin>

--- a/ruta-eclipse-update-site/category.xml
+++ b/ruta-eclipse-update-site/category.xml
@@ -20,7 +20,7 @@
    ***************************************************************
    -->
 <site>
-   <feature url="features/org.apache.uima.ruta.feature_3.1.0.jar" id="org.apache.uima.ruta.feature" version="3.1.0">
+   <feature url="features/org.apache.uima.ruta.feature_3.2.0.SNAPSHOT.jar" id="org.apache.uima.ruta.feature" version="3.2.0.SNAPSHOT">
       <category name="apache-uima-ruta"/>
    </feature>
    <category-def name="apache-uima-ruta" label="Apache UIMA Ruta">

--- a/ruta-eclipse-update-site/pom.xml
+++ b/ruta-eclipse-update-site/pom.xml
@@ -24,13 +24,13 @@
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>parent-pom</artifactId>
-    <version>14</version>
+    <version>15-SNAPSHOT</version>
     <relativePath />
   </parent>
 
   <artifactId>ruta-eclipse-update-site</artifactId>
   <packaging>pom</packaging>
-  <version>3.1.0</version>
+  <version>3.2.0-SNAPSHOT</version>
 
   <name>Apache UIMA Ruta Eclipse: ${project.artifactId}</name>
   <description>The UIMA Ruta Eclipse update site</description>
@@ -47,7 +47,7 @@
     <uimaScmProject>${project.artifactId}</uimaScmProject>
     <eclipseUpdateSiteComponent>ruta</eclipseUpdateSiteComponent>
     <eclipseUpdateSubSite>${project.build.directory}/eclipse-update-site-v3/${eclipseUpdateSiteComponent}</eclipseUpdateSubSite>
-    <dropPrevVersions>false</dropPrevVersions>
+    <dropPrevVersions>true</dropPrevVersions>
   </properties>
 
   <build>

--- a/ruta-ep-addons/pom.xml
+++ b/ruta-ep-addons/pom.xml
@@ -145,8 +145,6 @@
   </dependencies>
 
   <build>
-    <!-- don't use artifactId as first part of finalName, follow instead the eclipse convention -->
-    <finalName>org.apache.uima.ruta.addons_${parsedVersion.osgiVersion}</finalName>
     <resources>
       <resource>
         <directory>.</directory>

--- a/ruta-ep-caseditor/pom.xml
+++ b/ruta-ep-caseditor/pom.xml
@@ -106,8 +106,6 @@
   </dependencies>
 
   <build>
-    <!-- don't use artifactId as first part of finalName, follow instead the eclipse convention -->
-    <finalName>org.apache.uima.ruta.caseditor_${parsedVersion.osgiVersion}</finalName>
     <resources>
       <resource>
         <directory>.</directory>

--- a/ruta-ep-core-ext/pom.xml
+++ b/ruta-ep-core-ext/pom.xml
@@ -91,9 +91,6 @@
   </dependencies>
 
   <build>
-    <!-- don't use artifactId as first part of finalName, follow instead the eclipse convention -->
-    <finalName>org.apache.uima.ruta.core.ext_${parsedVersion.osgiVersion}</finalName>
-
     <plugins>
       <plugin>
         <groupId>org.apache.felix</groupId>

--- a/ruta-ep-engine/pom.xml
+++ b/ruta-ep-engine/pom.xml
@@ -192,9 +192,6 @@
   </dependencies>
 
   <build>
-    <!-- don't use artifactId as first part of finalName, follow instead
-      the eclipse convention -->
-    <finalName>org.apache.uima.ruta.engine_${parsedVersion.osgiVersion}</finalName>
     <resources>
       <resource>
         <directory>src/main/readme_src</directory>
@@ -211,8 +208,8 @@
             <configuration>
               <instructions>
                 <_nouses>true</_nouses>
-                <_exportcontents>org.apache.uima.ruta,
-                  org.apache.uima.ruta.cache,
+                <_exportcontents>
+                  org.apache.uima.ruta,
                   org.apache.uima.ruta.action,
                   org.apache.uima.ruta.condition,
                   org.apache.uima.ruta.constraint,
@@ -257,38 +254,63 @@
                 </_exportcontents>
 
                 <Import-Package>
-                  org.apache.uima.*,
-                  !bsh, !com.sun.net.httpserver,
+                  !org.apache.uima.fit.*,
+                  !bsh, 
+                  !com.sun.net.httpserver,
                   !edu.emory.mathcs.backport.java.util.concurrent,
-                  !groovy.lang, !javax.annotation,
+                  !groovy.lang, 
+                  !javax.annotation,
                   !javax.ejb,
-                  !javax.el, !javax.inject,
-                  !javax.interceptor, !javax.jms,
-                  !javax.management, !javax.management.modelmbean, !javax.management.openmbean,
+                  !javax.el, 
+                  !javax.inject,
+                  !javax.interceptor, 
+                  !javax.jms,
+                  !javax.management, 
+                  !javax.management.modelmbean, !javax.management.openmbean,
                   !javax.management.remote,
-                  !javax.naming, !javax.persistence.spi, !javax.rmi,
+                  !javax.naming, 
+                  !javax.persistence.spi, !javax.rmi,
                   !javax.servlet,
-                  !javax.swing, !javax.swing.border,
+                  !javax.swing, 
+                  !javax.swing.border,
                   !javax.swing.event,
-                  !javax.swing.text, !javax.swing.tree, !javax.validation,
+                  !javax.swing.text, 
+                  !javax.swing.tree, 
+                  !javax.validation,
                   !javax.validation.bootstrap,
-                  !javax.validation.metadata, !javax.xml.namespace,
-                  !javax.xml.parsers, !javax.xml.stream,
+                  !javax.validation.metadata, 
+                  !javax.xml.namespace,
+                  !javax.xml.parsers, 
+                  !javax.xml.stream,
                   !javax.xml.stream.events,
                   !javax.xml.stream.util,
-                  !javax.xml.transform, !javax.xml.transform.sax,
+                  !javax.xml.transform, 
+                  !javax.xml.transform.sax,
                   !javax.xml.transform.stax,
-                  !javax.xml.ws, !javax.xml.*, !joptsimple,
-                  !net.sf.cglib.*, !net.sf.ehcache.*,
+                  !javax.xml.ws, 
+                  !javax.xml.*, 
+                  !joptsimple,
+                  !net.sf.cglib.*, 
+                  !net.sf.ehcache.*,
                   !org.antlr.stringtemplate,
                   !org.apache.avalon.framework.logger,
-                  !org.apache.log, !org.apache.log4j,
+                  !org.apache.log, 
+                  !org.apache.log4j,
                   !org.apache.log4j.xml,
-                  !org.aspectj.*, !org.codehaus.groovy.*, !org.hibernate.* ,
-                  !org.joda.*, !org.jruby.*, !org.omg.CORBA,
+                  !org.aspectj.*, 
+                  !org.codehaus.groovy.*, 
+                  !org.hibernate.* ,
+                  !org.joda.*, 
+                  !org.jruby.*, 
+                  !org.omg.CORBA,
                   !org.springframework.instrument,
-                  !org.w3c.dom, !org.xml.sax, !org.xml.sax.ext, !org.xml.sax.helpers,
-                  !org.aopalliance.*, !org.springframework.aop.*
+                  !org.w3c.dom, 
+                  !org.xml.sax, 
+                  !org.xml.sax.ext, 
+                  !org.xml.sax.helpers,
+                  !org.aopalliance.*, 
+                  !org.springframework.aop.*,
+                  org.apache.uima.*
                 </Import-Package>
                 <!-- -->
                 <Require-Bundle>org.apache.uima.runtime</Require-Bundle>

--- a/ruta-ep-ide-ui/pom.xml
+++ b/ruta-ep-ide-ui/pom.xml
@@ -198,8 +198,6 @@
   </dependencies>
 
   <build>
-    <!-- don't use artifactId as first part of finalName, follow instead the eclipse convention -->
-    <finalName>org.apache.uima.ruta.ide.ui_${parsedVersion.osgiVersion}</finalName>
     <resources>
       <resource>
         <directory>.</directory>

--- a/ruta-ep-ide/pom.xml
+++ b/ruta-ep-ide/pom.xml
@@ -123,8 +123,6 @@
   </dependencies>
 
   <build>
-    <!-- don't use artifactId as first part of finalName, follow instead the eclipse convention -->
-    <finalName>org.apache.uima.ruta.ide_${parsedVersion.osgiVersion}</finalName>
     <resources>
       <resource>
         <directory>.</directory>

--- a/ruta-ep-textruler/pom.xml
+++ b/ruta-ep-textruler/pom.xml
@@ -96,8 +96,6 @@
   </dependencies>
 
   <build>
-    <!-- don't use artifactId as first part of finalName, follow instead the eclipse convention -->
-    <finalName>org.apache.uima.ruta.textruler_${parsedVersion.osgiVersion}</finalName>
     <resources>
       <resource>
         <directory>.</directory>


### PR DESCRIPTION
**JIRA Ticket:** https://issues.apache.org/jira/browse/UIMA-6458

**What's in the PR**
- Remove "finalName" from the Eclipse modules
- Update version in the Eclipse update site module
- Update to UIMA Parent POM 15-SNAPSHOT
- Set "dropPrevVersions" in the Eclipse update site module
- Changed engine bundle to not import the org.apache.uima.fit.* packages since it brings uimaFIT along and even exports its packages - without this e.g. org.apache.uima.fit.legacy would get imported which does not even exist anymore...

**How to test manually**
* Run build and {{find . -name "*parsed*"}}

**Automatic testing**
* [ ] PR adds/updates unit tests

**Documentation**
* [ ] PR adds/updates documentation

**Organizational**
- [ ] PR includes new dependencies.
      <sub><sup>Only dependencies under [approved licenses](http://www.apache.org/legal/resolved.html#category-a) are allowed. LICENSE and NOTICE files in the respective modules where dependencies have been added as well as in the project root have been updated.</sup></sub>
