### PR TITLE
Issue #100: Enable type system discovery via SPI in OSGI

### DIFF
--- a/ruta-basic-type/pom.xml
+++ b/ruta-basic-type/pom.xml
@@ -99,12 +99,6 @@
             <Export-Package>
               org.apache.uima.ruta.type
             </Export-Package>
-            <Require-Capability>
-              osgi.extender;filter:="(osgi.extender=osgi.serviceloader.registrar)"
-            </Require-Capability>
-            <Provide-Capability>
-              osgi.serviceloader;osgi.serviceloader=org.apache.uima.spi.JCasClassProvider
-            </Provide-Capability>
           </instructions>
         </configuration>
       </plugin>

--- a/ruta-core/pom.xml
+++ b/ruta-core/pom.xml
@@ -252,6 +252,17 @@
               org.apache.uima.ruta,
               org.apache.uima.ruta.*
             </Export-Package>
+            <!--
+              - These capabilities need to be declared here due to  
+              - https://issues.apache.org/jira/browse/ARIES-2082
+              -->
+            <Require-Capability>
+              osgi.extender;filter:="(osgi.extender=osgi.serviceloader.registrar)";resolution:=optional
+            </Require-Capability>
+            <Provide-Capability>
+              osgi.serviceloader;osgi.serviceloader=org.apache.uima.spi.TypeSystemDescriptionProvider,
+              osgi.serviceloader;osgi.serviceloader=org.apache.uima.spi.JCasClassProvider
+            </Provide-Capability>
           </instructions>
         </configuration>
       </plugin>

--- a/ruta-typesystem/pom.xml
+++ b/ruta-typesystem/pom.xml
@@ -112,13 +112,6 @@
               org.apache.uima.ruta.type.html,
               org.apache.uima.ruta.engine;-split-package:=merge-first
             </Export-Package>
-            <Require-Capability>
-              osgi.extender;filter:="(osgi.extender=osgi.serviceloader.registrar)"
-            </Require-Capability>
-            <Provide-Capability>
-              osgi.serviceloader;osgi.serviceloader=org.apache.uima.spi.TypeSystemDescriptionProvider,
-              osgi.serviceloader;osgi.serviceloader=org.apache.uima.spi.JCasClassProvider
-            </Provide-Capability>
           </instructions>
         </configuration>
       </plugin>


### PR DESCRIPTION
**What's in the PR**
- Move capabilitiy headers from type fragments to ruta-core bundle because of https://issues.apache.org/jira/browse/ARIES-2082
- Allow core bundle to resolve even if no serviceloader registrar is available

**How to test manually**
* Deploy in OSGI environment with spifly

**Automatic testing**
* [ ] PR adds/updates unit tests

**Documentation**
* [ ] PR adds/updates documentation

**Organizational**
- [ ] PR includes new dependencies.
      <sub><sup>Only dependencies under [approved licenses](http://www.apache.org/legal/resolved.html#category-a) are allowed. LICENSE and NOTICE files in the respective modules where dependencies have been added as well as in the project root have been updated.</sup></sub>
