### PR TITLE
Issue #110: Usage of labels within macro action definition is broken

### DIFF
--- a/ruta-core/src/main/java/org/apache/uima/ruta/action/MacroAction.java
+++ b/ruta-core/src/main/java/org/apache/uima/ruta/action/MacroAction.java
@@ -98,14 +98,6 @@ public class MacroAction extends AbstractRutaAction {
     }
   }
 
-  @Override
-  public void setLabel(String label) {
-    super.setLabel(label);
-    for (AbstractRutaAction action : actions) {
-      action.setLabel(label);
-    }
-  }
-
   public String getName() {
     return name;
   }


### PR DESCRIPTION


**JIRA Ticket:** https://issues.apache.org/jira/browse/UIMA-XXXX

**What's in the PR**
- changed conventions of usage
- deactivated auto labelling of all action within marco definitions
- collect inlined labels in rule preparation
- added and modified tests

**How to test manually**
* ...

**Automatic testing**
* [x] PR adds/updates unit tests

**Documentation**
* [ ] PR adds/updates documentation

**Organizational**
- [ ] PR includes new dependencies.
      <sub><sup>Only dependencies under [approved licenses](http://www.apache.org/legal/resolved.html#category-a) are allowed. LICENSE and NOTICE files in the respective modules where dependencies have been added as well as in the project root have been updated.</sup></sub>
