### PR TITLE
Issue #133: Update dependencies

### DIFF
--- a/ruta-maven-plugin/pom.xml
+++ b/ruta-maven-plugin/pom.xml
@@ -127,7 +127,7 @@
               <tagletArtifact>
                 <groupId>org.apache.maven.plugin-tools</groupId>
                 <artifactId>maven-plugin-tools-javadoc</artifactId>
-                <version>2.9</version>
+                <version>3.5.2</version>
               </tagletArtifact>
             </tagletArtifacts>
           </configuration>

--- a/ruta-parent/pom.xml
+++ b/ruta-parent/pom.xml
@@ -48,24 +48,6 @@
   </scm>
 
   <repositories>
-    <!-- modify central repository access: Turn on checksum checking -->
-    <repository>
-      <id>central</id>
-      <name>Maven Repository Switchboard</name>
-      <layout>default</layout>
-      <url>https://repo1.maven.org/maven2</url>
-
-      <releases>
-        <enabled>true</enabled>
-        <checksumPolicy>fail</checksumPolicy>
-        <updatePolicy>never</updatePolicy>
-      </releases>
-
-      <snapshots>
-        <enabled>false</enabled>
-      </snapshots>
-    </repository>
-    
     <!--
       - The Eclipse Plugin modules use version ranges for their dependencies. These could resolve to
       - SNAPSHOT versions if we have a SNAPSHOT repo declaration here. Thus, this repo should only


### PR DESCRIPTION
**What's in the PR**
- maven-plugin-tools-javadoc 2.9 -> 3.5.2
- Remove Maven Central repo override which is already present in the Apache UIMA Parent POM

**How to test manually**
* No specific test procedure

**Automatic testing**
* [ ] PR adds/updates unit tests

**Documentation**
* [ ] PR adds/updates documentation

**Organizational**
- [ ] PR includes new dependencies.
      <sub><sup>Only dependencies under [approved licenses](http://www.apache.org/legal/resolved.html#category-a) are allowed. LICENSE and NOTICE files in the respective modules where dependencies have been added as well as in the project root have been updated.</sup></sub>
