### PR TITLE
Issue #133: Update dependencies

### DIFF
--- a/ruta-eclipse-feature/feature.xml
+++ b/ruta-eclipse-feature/feature.xml
@@ -150,7 +150,7 @@ Apache UIMA is a trademark of the Apache Software Foundation in the United State
 
    <requires>
       <import feature="org.apache.uima.tools" version="3.5.0" match="greaterOrEqual"/>
-      <import feature="org.eclipse.dltk.core" version="5.11.0" match="greaterOrEqual"/>
+      <import feature="org.eclipse.dltk.core" version="5.11.0" match="compatible"/>
    </requires>
 
    <plugin

--- a/ruta-eclipse-update-site/category.xml
+++ b/ruta-eclipse-update-site/category.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-  <!--
+<!--
    ***************************************************************
    * Licensed to the Apache Software Foundation (ASF) under one
    * or more contributor license agreements.  See the NOTICE file
@@ -28,4 +28,5 @@
          Apache UIMA Ruta
       </description>
    </category-def>
+   <repository-reference location="https://download.eclipse.org/releases/2018-12/" enabled="true" />
 </site>

--- a/ruta-ep-ide-ui/src/main/java/org/apache/uima/ruta/ide/debug/ui/launchConfiguration/RutaCommonTab.java
+++ b/ruta-ep-ide-ui/src/main/java/org/apache/uima/ruta/ide/debug/ui/launchConfiguration/RutaCommonTab.java
@@ -92,7 +92,7 @@ import org.eclipse.ui.dialogs.ElementTreeSelectionDialog;
 import org.eclipse.ui.ide.IDEEncoding;
 import org.eclipse.ui.model.WorkbenchContentProvider;
 import org.eclipse.ui.model.WorkbenchLabelProvider;
-import org.eclipse.ui.views.navigator.ResourceSorter;
+import org.eclipse.ui.views.navigator.ResourceComparator;
 
 /**
  * Launch configuration tab used to specify the location a launch configuration is stored in,
@@ -308,7 +308,7 @@ public class RutaCommonTab extends AbstractLaunchConfigurationTab {
         dialog.setTitle(LaunchConfigurationsMessages.CommonTab_13);
         dialog.setMessage(LaunchConfigurationsMessages.CommonTab_14);
         dialog.setInput(ResourcesPlugin.getWorkspace().getRoot());
-        dialog.setSorter(new ResourceSorter(ResourceSorter.NAME));
+        dialog.setComparator(new ResourceComparator(ResourceComparator.NAME));
         if (dialog.open() == IDialogConstants.OK_ID) {
           IResource resource = (IResource) dialog.getFirstResult();
           String arg = resource.getFullPath().toString();

--- a/ruta-ep-ide-ui/src/main/java/org/apache/uima/ruta/ide/ui/preferences/RutaSmartTypingConfigurationBlock.java
+++ b/ruta-ep-ide-ui/src/main/java/org/apache/uima/ruta/ide/ui/preferences/RutaSmartTypingConfigurationBlock.java
@@ -19,13 +19,13 @@
 
 package org.apache.uima.ruta.ide.ui.preferences;
 
+import java.text.MessageFormat;
 import java.util.ArrayList;
 import java.util.List;
 
 import org.apache.uima.ruta.ide.RutaIdeUIPlugin;
 import org.apache.uima.ruta.ide.ui.RutaPreferenceConstants;
 import org.eclipse.core.runtime.Assert;
-import org.eclipse.dltk.internal.corext.util.Messages;
 import org.eclipse.dltk.ui.CodeFormatterConstants;
 import org.eclipse.dltk.ui.PreferenceConstants;
 import org.eclipse.dltk.ui.preferences.AbstractConfigurationBlock;
@@ -76,6 +76,7 @@ class RutaSmartTypingConfigurationBlock extends AbstractConfigurationBlock {
             .toArray(new OverlayPreferenceStore.OverlayKey[keys.size()]);
   }
 
+  @Override
   public Control createControl(Composite parent) {
     Composite control = new Composite(parent, SWT.NONE);
     GridLayout layout = new GridLayout();
@@ -148,14 +149,15 @@ class RutaSmartTypingConfigurationBlock extends AbstractConfigurationBlock {
     String text;
     String indentMode = RutaIdeUIPlugin.getDefault().getPreferenceStore()
             .getString(CodeFormatterConstants.FORMATTER_TAB_CHAR);
-    if (CodeFormatterConstants.TAB.equals(indentMode))
-      text = Messages.format(
+    if (CodeFormatterConstants.TAB.equals(indentMode)) {
+      text = MessageFormat.format(
               PreferencesMessages.SmartTypingConfigurationBlock_tabs_message_tab_text,
-              new String[] { Integer.toString(getTabDisplaySize()) });
-    else
-      text = Messages.format(
+              Integer.toString(getTabDisplaySize()));
+    } else {
+      text = MessageFormat.format(
               PreferencesMessages.SmartTypingConfigurationBlock_tabs_message_others_text,
-              new String[] { Integer.toString(getTabDisplaySize()), getIndentMode() });
+              Integer.toString(getTabDisplaySize()), getIndentMode());
+    }
 
     final Link link = new Link(composite, SWT.NONE);
     link.setText(text);
@@ -175,11 +177,14 @@ class RutaSmartTypingConfigurationBlock extends AbstractConfigurationBlock {
     final IPropertyChangeListener propertyChangeListener = new IPropertyChangeListener() {
       private boolean fHasRun = false;
 
+      @Override
       public void propertyChange(PropertyChangeEvent event) {
-        if (fHasRun)
+        if (fHasRun) {
           return;
-        if (composite.isDisposed())
+        }
+        if (composite.isDisposed()) {
           return;
+        }
         String property = event.getProperty();
         if (CodeFormatterConstants.FORMATTER_TAB_CHAR.equals(property)
                 || CodeFormatterConstants.FORMATTER_TAB_SIZE.equals(property)) {
@@ -194,6 +199,7 @@ class RutaSmartTypingConfigurationBlock extends AbstractConfigurationBlock {
     };
     combinedStore.addPropertyChangeListener(propertyChangeListener);
     link.addDisposeListener(new DisposeListener() {
+      @Override
       public void widgetDisposed(org.eclipse.swt.events.DisposeEvent e) {
         combinedStore.removePropertyChangeListener(propertyChangeListener);
       }
@@ -204,14 +210,17 @@ class RutaSmartTypingConfigurationBlock extends AbstractConfigurationBlock {
     String indentMode = RutaIdeUIPlugin.getDefault().getPreferenceStore()
             .getString(CodeFormatterConstants.FORMATTER_TAB_CHAR);
 
-    if (CodeFormatterConstants.SPACE.equals(indentMode))
+    if (CodeFormatterConstants.SPACE.equals(indentMode)) {
       return PreferencesMessages.SmartTypingConfigurationBlock_tabs_message_spaces;
+    }
 
-    if (CodeFormatterConstants.TAB.equals(indentMode))
+    if (CodeFormatterConstants.TAB.equals(indentMode)) {
       return PreferencesMessages.SmartTypingConfigurationBlock_tabs_message_tabs;
+    }
 
-    if (CodeFormatterConstants.MIXED.equals(indentMode))
+    if (CodeFormatterConstants.MIXED.equals(indentMode)) {
       return PreferencesMessages.SmartTypingConfigurationBlock_tabs_message_tabsAndSpaces;
+    }
 
     Assert.isTrue(false, "Illegal indent mode - must not happen"); //$NON-NLS-1$
     return null;

--- a/ruta-ep-parent/pom.xml
+++ b/ruta-ep-parent/pom.xml
@@ -51,13 +51,13 @@
 
   <dependencies>
     <dependency>
-      <groupId>${eclipseP2RepoId}</groupId>
+      <groupId>${dltkP2RepoId}</groupId>
       <artifactId>org.eclipse.dltk.core</artifactId>
       <version>${dltk.version}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>${eclipseP2RepoId}</groupId>
+      <groupId>${dltkP2RepoId}</groupId>
       <artifactId>org.eclipse.dltk.ui</artifactId>
       <version>${dltk.version}</version>
       <scope>provided</scope>
@@ -66,25 +66,25 @@
           <!-- 
             The p2 resolver appears to have trouble with the "icu-data" classifier
            -->
-          <groupId>${eclipseP2RepoId}</groupId>
+          <groupId>${dltkP2RepoId}</groupId>
           <artifactId>com.ibm.icu</artifactId>
         </exclusion>
       </exclusions>
     </dependency>
     <dependency>
-      <groupId>${eclipseP2RepoId}</groupId>
+      <groupId>${dltkP2RepoId}</groupId>
       <artifactId>org.eclipse.dltk.debug</artifactId>
       <version>${dltk.version}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>${eclipseP2RepoId}</groupId>
+      <groupId>${dltkP2RepoId}</groupId>
       <artifactId>org.eclipse.dltk.annotations</artifactId>
       <version>${dltk.version}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>${eclipseP2RepoId}</groupId>
+      <groupId>${dltkP2RepoId}</groupId>
       <artifactId>org.eclipse.dltk.launching</artifactId>
       <version>${dltk.version}</version>
       <scope>provided</scope>
@@ -99,31 +99,31 @@
       </exclusions>
     </dependency>
     <dependency>
-      <groupId>${eclipseP2RepoId}</groupId>
+      <groupId>${dltkP2RepoId}</groupId>
       <artifactId>org.eclipse.dltk.core.manipulation</artifactId>
       <version>${dltk.version}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>${eclipseP2RepoId}</groupId>
+      <groupId>${dltkP2RepoId}</groupId>
       <artifactId>org.eclipse.dltk.validators.core</artifactId>
       <version>${dltk.version}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>${eclipseP2RepoId}</groupId>
+      <groupId>${dltkP2RepoId}</groupId>
       <artifactId>org.eclipse.dltk.console</artifactId>
       <version>${dltk.version}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>${eclipseP2RepoId}</groupId>
+      <groupId>${dltkP2RepoId}</groupId>
       <artifactId>org.eclipse.dltk.formatter</artifactId>
       <version>${dltk.version}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>${eclipseP2RepoId}</groupId>
+      <groupId>${dltkP2RepoId}</groupId>
       <artifactId>org.eclipse.dltk.testing</artifactId>
       <version>${dltk.version}</version>
       <scope>provided</scope>

--- a/ruta-parent/pom.xml
+++ b/ruta-parent/pom.xml
@@ -67,6 +67,11 @@
 
     <repository>
       <id>${eclipseP2RepoId}</id>
+      <url>https://download.eclipse.org/releases/2023-12/</url>
+      <layout>p2</layout>
+    </repository>
+    <repository>
+      <id>${dltkP2RepoId}</id>
       <url>https://download.eclipse.org/releases/2018-12/</url>
       <layout>p2</layout>
     </repository>
@@ -145,7 +150,8 @@
     <maven.compiler.release>17</maven.compiler.release>
     <execution.environment>JavaSE-17</execution.environment>
 
-    <eclipseP2RepoId>org.eclipse.p2.201812</eclipseP2RepoId>
+    <eclipseP2RepoId>org.eclipse.p2.202312</eclipseP2RepoId>
+    <dltkP2RepoId>org.eclipse.p2.201812</dltkP2RepoId>
 
     <api_check_oldVersion>3.3.0</api_check_oldVersion>
   </properties>


### PR DESCRIPTION
**What's in the PR**
- Switch to Eclipse 2023-09 baseline
- Force dependency on DLTK 5.11.0
- Add Eclipse 2018-12 update site as a reference repository to the Ruta feature so users can get DLTK 5.11.0 which is no longer included in recent Eclipse releases
- Replace some uses of deprecated API

**How to test manually**
* Build and try installing the result into Eclipse 2023-09

**Automatic testing**
* [ ] PR adds/updates unit tests

**Documentation**
* [ ] PR adds/updates documentation

**Organizational**
- [ ] PR includes new dependencies.
      <sub><sup>Only dependencies under [approved licenses](http://www.apache.org/legal/resolved.html#category-a) are allowed. LICENSE and NOTICE files in the respective modules where dependencies have been added as well as in the project root have been updated.</sup></sub>
