### PR TITLE
Issue #151: Unable to use Ruta Query view in Ruta 3.4.0-RC-1

### DIFF
--- a/ruta-ep-core-ext/pom.xml
+++ b/ruta-ep-core-ext/pom.xml
@@ -19,17 +19,22 @@
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
-  <artifactId>ruta-ep-core-ext</artifactId>
-  <name>Apache UIMA Ruta Eclipse: ${project.artifactId}</name>
+
   <parent>
     <groupId>org.apache.uima</groupId>
     <artifactId>ruta-ep-parent</artifactId>
     <version>3.4.0-SNAPSHOT</version>
     <relativePath>../ruta-ep-parent/pom.xml</relativePath>
   </parent>
+  
+  <artifactId>ruta-ep-core-ext</artifactId>
+  <name>Apache UIMA Ruta Eclipse: ${project.artifactId}</name>
+  <description>Eclipse plugin for providing the implementions of the additional language extensions in the UIMA Ruta Workbench</description>
+
   <properties>
     <postNoticeText />
   </properties>
+
   <url>${uimaWebsiteUrl}</url>
 
   <scm>
@@ -44,19 +49,16 @@
       <groupId>org.apache.uima</groupId>
       <artifactId>ruta-core</artifactId>
       <version>${project.parent.version}</version>
-      <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.uima</groupId>
       <artifactId>ruta-core-ext</artifactId>
       <version>${project.parent.version}</version>
-      <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.uima</groupId>
       <artifactId>ruta-ep-ide</artifactId>
       <version>${project.parent.version}</version>
-      <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.uima</groupId>
@@ -96,31 +98,32 @@
             <configuration>
               <instructions>
                 <_nouses>true</_nouses>
-                <_exportcontents>
-                  org.apache.uima.ruta
-                </_exportcontents>
                 <Require-Bundle>
                   org.apache.uima.runtime,
                   org.apache.uima.ruta.engine,
                   org.apache.uima.ruta.ide,
                   org.apache.uima.ruta.ide.ui,
-                  org.eclipse.dltk.core;bundle-version="3.0.0"
+                  org.eclipse.dltk.core;bundle-version="5.11.0"
                 </Require-Bundle>
                 <Import-Package>
                 </Import-Package>
+                <Export-Package>
+                  !*
+                </Export-Package>
                 <Bundle-SymbolicName>org.apache.uima.ruta.core.ext;singleton:=true</Bundle-SymbolicName>
                 <Bundle-RequiredExecutionEnvironment>${execution.environment}</Bundle-RequiredExecutionEnvironment>
                 <Bundle-ActivationPolicy>lazy</Bundle-ActivationPolicy>
                 <Eclipse-ExtensibleAPI>true</Eclipse-ExtensibleAPI>
                 <Eclipse-BuddyPolicy>registered</Eclipse-BuddyPolicy>
-                <Eclipse-RegisterBuddy>org.apache.uima.runtime,org.apache.uima.ruta.engine</Eclipse-RegisterBuddy>
+                <Eclipse-RegisterBuddy>
+                  org.apache.uima.runtime,
+                  org.apache.uima.ruta.engine
+                </Eclipse-RegisterBuddy>
               </instructions>
             </configuration>
           </execution>
         </executions>
       </plugin>
-
     </plugins>
   </build>
-  <description>Eclipse plugin for providing the implementions of the additional language extensions in the UIMA Ruta Workbench</description>
 </project>

--- a/ruta-ep-engine/pom.xml
+++ b/ruta-ep-engine/pom.xml
@@ -169,12 +169,10 @@
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-simple</artifactId>
-      <version>1.7.30</version>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
-      <version>1.7.30</version>
     </dependency>
 
   </dependencies>

--- a/ruta-parent/pom.xml
+++ b/ruta-parent/pom.xml
@@ -194,6 +194,11 @@
       </dependency>
       <dependency>
         <groupId>org.slf4j</groupId>
+        <artifactId>slf4j-simple</artifactId>
+        <version>${slf4j-version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.slf4j</groupId>
         <artifactId>slf4j-jdk14</artifactId>
         <version>${slf4j-version}</version>
         <scope>test</scope>


### PR DESCRIPTION
**What's in the PR**
- Make sure that ruta-ext Eclipse plugin does not export the  org.apache.uima.ruta package
- Bit of cleaning up

**How to test manually**
* See issue description

**Automatic testing**
* [ ] PR adds/updates unit tests

**Documentation**
* [ ] PR adds/updates documentation

**Organizational**
- [ ] PR includes new dependencies.
      <sub><sup>Only dependencies under [approved licenses](http://www.apache.org/legal/resolved.html#category-a) are allowed. LICENSE and NOTICE files in the respective modules where dependencies have been added as well as in the project root have been updated.</sup></sub>
