### PR TITLE
Issue #176: Upgrade dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -89,7 +89,7 @@
     <dependency>
       <groupId>org.apache.uima</groupId>
       <artifactId>ruta-maven-plugin</artifactId>
-      <version>${project.version}</version>
+      <version>3.4.1</version>
     </dependency>
   </dependencies>
 

--- a/ruta-core/pom.xml
+++ b/ruta-core/pom.xml
@@ -289,7 +289,6 @@
       <plugin>
         <groupId>org.antlr</groupId>
         <artifactId>antlr3-maven-plugin</artifactId>
-        <version>3.5.2</version>
         <executions>
           <execution>
             <id>run antlr</id>

--- a/ruta-documentation/pom.xml
+++ b/ruta-documentation/pom.xml
@@ -96,11 +96,6 @@
         </executions>
         <dependencies>
           <dependency>
-              <groupId>org.jruby</groupId>
-              <artifactId>jruby</artifactId>
-              <version>9.4.3.0</version>
-          </dependency>
-          <dependency>
             <groupId>org.asciidoctor</groupId>
             <artifactId>asciidoctorj</artifactId>
             <version>${asciidoctor.version}</version>

--- a/ruta-ep-engine/src/main/readme_bin/LICENSE
+++ b/ruta-ep-engine/src/main/readme_bin/LICENSE
@@ -483,9 +483,9 @@ licensed under the Common Public License.
 
 =======================================================================
 
-SPRING FRAMEWORK 5.3.30 SUBCOMPONENTS:
+SPRING FRAMEWORK 6.1.15 SUBCOMPONENTS:
 
-Spring Framework 5.3.30 includes a number of subcomponents
+Spring Framework 6.1.15 includes a number of subcomponents
 with separate copyright notices and license terms. The product that
 includes this file does not necessarily use all the open source
 subcomponents referred to below. Your use of the source
@@ -536,10 +536,18 @@ CGLIB 3.3 is licensed under the Apache License, version 2.0, the text of which
 is included above.
 
 
->>> Objenesis 3.2 (org.objenesis:objenesis:3.2):
+>>> JavaPoet 1.13.0 (com.squareup:javapoet:1.13.0):
+
+Per the LICENSE file in the JavaPoet JAR distribution downloaded from
+https://github.com/square/javapoet/archive/refs/tags/javapoet-1.13.0.zip,
+JavaPoet 1.13.0 is licensed under the Apache License, version 2.0, the text of
+which is included above.
+
+
+>>> Objenesis 3.4 (org.objenesis:objenesis:3.4):
 
 Per the LICENSE file in the Objenesis ZIP distribution downloaded from
-http://objenesis.org/download.html, Objenesis 3.2 is licensed under the
+http://objenesis.org/download.html, Objenesis 3.4 is licensed under the
 Apache License, version 2.0, the text of which is included above.
 
 Per the NOTICE file in the Objenesis ZIP distribution downloaded from
@@ -568,7 +576,6 @@ medium.
 This offer to obtain a copy of the Source Files is valid for three years from
 the date you acquired this Software product. Alternatively, the Source Files
 may accompany the Software.
-
 
 ==================================================================================================== 
 

--- a/ruta-ep-engine/src/main/readme_bin/NOTICE
+++ b/ruta-ep-engine/src/main/readme_bin/NOTICE
@@ -23,17 +23,17 @@ licensed under the MIT License.
 ################################################################################
 
 This product contains Apache Commons Collections
-Copyright 2001-2019 The Apache Software Foundation
+Copyright 2001-2024 The Apache Software Foundation
 
 ################################################################################
 
 This product contains Apache Commons IO
-Copyright 2002-2021 The Apache Software Foundation
+Copyright 2002-2024 The Apache Software Foundation
 
 ################################################################################
 
 This product contains Apache Commons Lang
-Copyright 2001-2021 The Apache Software Foundation
+Copyright 2001-2024 The Apache Software Foundation
 
 ################################################################################
 
@@ -60,8 +60,8 @@ Copyright 2014-2020 The Apache Software Foundation
 
 ################################################################################
 
-Spring Framework 5.3.30
-Copyright (c) 2002-2023 Pivotal, Inc.
+Spring Framework 6.1.15
+Copyright (c) 2002-2024 Pivotal, Inc.
 
 This product is licensed to you under the Apache License, Version 2.0
 (the "License"). You may not use this product except in compliance with

--- a/ruta-ep-ide/pom.xml
+++ b/ruta-ep-ide/pom.xml
@@ -150,7 +150,6 @@
       <plugin>
         <groupId>org.antlr</groupId>
         <artifactId>antlr3-maven-plugin</artifactId>
-        <version>3.5.2</version>
         <executions>
           <execution>
             <id>run antlr</id>

--- a/ruta-maven-archetype/pom.xml
+++ b/ruta-maven-archetype/pom.xml
@@ -54,7 +54,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-archetype-plugin</artifactId>
-          <version>3.1.2</version>
+          <version>3.3.1</version>
         </plugin>
         <plugin>
           <groupId>org.apache.rat</groupId>

--- a/ruta-parent/pom.xml
+++ b/ruta-parent/pom.xml
@@ -117,33 +117,28 @@
       Creative Commons Attribution 3.0 License.
     </postNoticeText>
     
-    <tycho-version>4.0.4</tycho-version>
-
-    <uima-version>3.6.0-SNAPSHOT</uima-version>
-    <spring-version>5.3.39</spring-version>
-
-    <slf4j-version>1.7.36</slf4j-version>
-    <maven.version>3.8.1</maven.version>
-
-    <junit-version>5.11.3</junit-version>
-    <junit-vintage-version>4.13.2</junit-vintage-version>
-    <assertj-version>3.26.3</assertj-version>
- 
     <antlr-version>3.5.3</antlr-version>
-    <htmlparser-version>1.6</htmlparser-version>
+    <assertj-version>3.26.3</assertj-version>
+    <caffeine-version>3.1.8</caffeine-version>
     <commons-collections-version>3.2.2</commons-collections-version>
     <commons-collections4-version>4.4</commons-collections4-version>
     <commons-text-version>1.12.0</commons-text-version>
     <commons-lang3-version>3.17.0</commons-lang3-version>
-    <commons-io-version>2.17.0</commons-io-version>
+    <commons-io-version>2.18.0</commons-io-version>
     <commons-math3-version>3.6.1</commons-math3-version>
     <commons-logging-version>1.3.4</commons-logging-version>
     <commons-logging-api-version>1.1</commons-logging-api-version>
-    <caffeine-version>3.1.8</caffeine-version>
-
     <dltk.version>[5.11.0,6.0.0)</dltk.version>
+    <htmlparser-version>1.6</htmlparser-version>
+    <junit-version>5.11.3</junit-version>
+    <junit-vintage-version>4.13.2</junit-vintage-version>
+    <maven.version>3.8.1</maven.version>
+    <slf4j-version>1.7.36</slf4j-version>
+    <spring-version>6.1.15</spring-version>
+    <tycho-version>4.0.10</tycho-version>
+    <uima-version>3.6.0-SNAPSHOT</uima-version>
 
-    <asciidoctor.plugin.version>3.1.0</asciidoctor.plugin.version>
+    <asciidoctor.plugin.version>3.1.1</asciidoctor.plugin.version>
     <asciidoctor.version>3.0.0</asciidoctor.version>
     <asciidoctor.pdf.version>2.3.19</asciidoctor.pdf.version>
 
@@ -155,13 +150,13 @@
     <eclipseP2RepoId>org.eclipse.p2.202309</eclipseP2RepoId>
     <dltkP2RepoId>org.eclipse.p2.201812</dltkP2RepoId>
 
-    <api_check_oldVersion>3.4.0</api_check_oldVersion>
-
     <!-- BEGIN PROFILE SETTINGS: generate-release-notes-->
     <github-repository>uima-ruta</github-repository>
     <git-branch>main</git-branch>
     <previous-release-version>3.4.0</previous-release-version>
     <!-- END PROFILE SETTINGS: generate-release-notes-->
+    
+    <api_check_oldVersion>${previous-release-version}</api_check_oldVersion>
   </properties>
 
   <dependencyManagement>
@@ -558,6 +553,11 @@
     <pluginManagement>
       <plugins>
         <plugin>
+          <groupId>org.antlr</groupId>
+          <artifactId>antlr3-maven-plugin</artifactId>
+          <version>${antlr-version}</version>
+        </plugin>
+        <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-surefire-plugin</artifactId>
           <dependencies>
@@ -580,7 +580,7 @@
       <plugin>
         <groupId>org.openntf.maven</groupId>
         <artifactId>p2-layout-resolver</artifactId>
-        <version>1.7.0</version>
+        <version>1.9.0</version>
         <extensions>true</extensions>
       </plugin>
 


### PR DESCRIPTION
**What's in the PR**
- Pin ruta-maven-plugin version to 3.4.1 because Maven does not like using a plugin that has been created in the same reactor
- antlr3-maven-plugin 3.5.2 -> 3.5.3
- tycho 4.0.4 -> 4.0.10
- commons-io 2.17.0 -> 2.18.0
- spring 5.3.39 -> 6.1.15
- asciidoctor-maven-plugin 3.1.0 -> 3.1.1
- p2-layout-resolver 1.7.0 -> 1.9.0
- maven-archetype-plugin 3.1.2 -> 3.3.1
- Removed explicit jruby dependency from asciidoc plugin

**How to test manually**
* No specific test procedure

**Automatic testing**
* [ ] PR adds/updates unit tests

**Documentation**
* [ ] PR adds/updates documentation

**Organizational**
- [x] PR includes new dependencies.
      <sub><sup>Only dependencies under [approved licenses](http://www.apache.org/legal/resolved.html#category-a) are allowed. LICENSE and NOTICE files in the respective modules where dependencies have been added as well as in the project root have been updated.</sup></sub>
