### PR TITLE
Issue #177: Consider resource manager when loading type descriptions

### DIFF
--- a/ruta-core/pom.xml
+++ b/ruta-core/pom.xml
@@ -171,8 +171,7 @@
                   <exclude>src/main/resources/META-INF/org.apache.uima.fit/*.txt</exclude>
                   <exclude>input/**</exclude> <!-- temp test data -->
                   <exclude>TypeSystem.xml</exclude> <!-- temp test data -->
-                  <exclude>src/main/resources/META-INF/services/org.apache.uima.spi.JCasClassProvider</exclude>
-                  <exclude>src/main/resources/META-INF/services/org.apache.uima.spi.TypeSystemDescriptionProvider</exclude>
+                  <exclude>src/main/resources/META-INF/services/org.apache.uima.spi.TypeSystemProvider</exclude>
                 </excludes>
               </configuration>
             </execution>
@@ -243,8 +242,7 @@
               osgi.extender;filter:="(osgi.extender=osgi.serviceloader.registrar)";resolution:=optional
             </Require-Capability>
             <Provide-Capability>
-              osgi.serviceloader;osgi.serviceloader=org.apache.uima.spi.TypeSystemDescriptionProvider,
-              osgi.serviceloader;osgi.serviceloader=org.apache.uima.spi.JCasClassProvider
+              osgi.serviceloader;osgi.serviceloader=org.apache.uima.spi.TypeSystemProvider
             </Provide-Capability>
           </instructions>
         </configuration>

--- a/ruta-core/src/main/java/org/apache/uima/ruta/type/spi/RutaTypeSystemProvider.java
+++ b/ruta-core/src/main/java/org/apache/uima/ruta/type/spi/RutaTypeSystemProvider.java
@@ -20,9 +20,9 @@ package org.apache.uima.ruta.type.spi;
 
 import org.apache.uima.spi.TypeSystemProvider_ImplBase;
 
-public class RutaTypeSystemDescriptionProvider extends TypeSystemProvider_ImplBase {
+public class RutaTypeSystemProvider extends TypeSystemProvider_ImplBase {
 
-  public RutaTypeSystemDescriptionProvider() {
+  public RutaTypeSystemProvider() {
     setTypeSystemLocations( //
             "/org/apache/uima/ruta/engine/BasicTypeSystem.xml", //
             "/org/apache/uima/ruta/engine/DefaultSeederTypeSystem.xml", //

--- a/ruta-core/src/main/resources/META-INF/services/org.apache.uima.spi.TypeSystemProvider
+++ b/ruta-core/src/main/resources/META-INF/services/org.apache.uima.spi.TypeSystemProvider
@@ -1,0 +1,1 @@
+org.apache.uima.ruta.type.spi.RutaTypeSystemProvider


### PR DESCRIPTION
**What's in the PR**
- Rename SPI class
- Add SPI discovery file to META-INF/services (only with the 3.6.0 SPI interface, not with the legacy interfaces)

**How to test manually**
* Try discovering types and JCas classes via SPI (requires classloader isolation)

**Automatic testing**
* [ ] PR adds/updates unit tests

**Documentation**
* [ ] PR adds/updates documentation

**Organizational**
- [ ] PR includes new dependencies.
      <sub><sup>Only dependencies under [approved licenses](http://www.apache.org/legal/resolved.html#category-a) are allowed. LICENSE and NOTICE files in the respective modules where dependencies have been added as well as in the project root have been updated.</sup></sub>
